### PR TITLE
Use custom JARs to build SCDF 2.11.0-RC1

### DIFF
--- a/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/.gitignore
+++ b/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/.gitignore
@@ -1,0 +1,1 @@
+components/

--- a/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/Dockerfile
+++ b/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/Dockerfile
@@ -11,10 +11,10 @@ LABEL com.vmware.cp.artifact.flavor="sha256:1e1b4657a77f0d47e9220f0c37b9bf780258
       org.opencontainers.image.created="2023-09-04T19:52:31Z" \
       org.opencontainers.image.description="Application packaged by VMware, Inc" \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="2.10.3-debian-11-r108" \
+      org.opencontainers.image.ref.name="2.11.0-RC1-debian-11-r108" \
       org.opencontainers.image.title="spring-cloud-dataflow-composed-task-runner" \
       org.opencontainers.image.vendor="VMware, Inc." \
-      org.opencontainers.image.version="2.10.3"
+      org.opencontainers.image.version="2.11.0-RC1"
 
 ENV HOME="/" \
     OS_ARCH="${TARGETARCH:-amd64}" \
@@ -28,7 +28,6 @@ RUN install_packages ca-certificates curl procps zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "java-17.0.8-7-3-linux-${OS_ARCH}-debian-11" \
-      "spring-cloud-dataflow-composed-task-runner-2.10.3-3-linux-${OS_ARCH}-debian-11" \
     ) && \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \
@@ -39,6 +38,18 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
+
+# Custom: also install local components in case Bitnami hasn't built the artifacts yet
+COPY components/* /tmp/bitnami/pkg/cache/
+RUN cd /tmp/bitnami/pkg/cache/ && \
+    LOCAL_COMPONENTS=( \
+      "spring-cloud-dataflow-composed-task-runner-2.11.0-RC1-linux-${OS_ARCH}-debian-11" \
+    ) && \
+    for LOCAL_COMPONENT in "${LOCAL_COMPONENTS[@]}"; do \
+      tar -zxf "${LOCAL_COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
+      rm -rf "${LOCAL_COMPONENT}".tar.gz{,.sha256} ; \
+    done
+
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives

--- a/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/Dockerfile
+++ b/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir /.m2 && chmod -R g+rwX /.m2
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/java/postunpack.sh
-ENV APP_VERSION="2.10.3" \
+ENV APP_VERSION="2.11.0" \
     BITNAMI_APP_NAME="spring-cloud-dataflow-composed-task-runner" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:$PATH"

--- a/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/custom-jar.sh
+++ b/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/custom-jar.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+
+mkdir components
+cd components
+
+# Download an existing GA archive
+wget https://downloads.bitnami.com/files/stacksmith/spring-cloud-dataflow-composed-task-runner-2.10.3-3-linux-amd64-debian-11.tar.gz
+# Explode it
+tar -xzf spring-cloud-dataflow-composed-task-runner-2.10.3-3-linux-amd64-debian-11.tar.gz
+
+# Navigate to JARs
+cd spring-cloud-dataflow-composed-task-runner-2.10.3-linux-amd64-debian-11/files/spring-cloud-dataflow-composed-task-runner/
+
+# Clean this - we'll replace with a different version
+rm *.jar
+
+wget https://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-dataflow-composed-task-runner/2.11.0-RC1/spring-cloud-dataflow-composed-task-runner-2.11.0-RC1.jar
+
+# This is symlinked in the original archive, so create another pointing to our version
+ln -s spring-cloud-dataflow-composed-task-runner-2.11.0-RC1.jar scdf-composed-task-runner.jar
+
+# Back out and rename to new version
+cd ../../../
+mv spring-cloud-dataflow-composed-task-runner-2.10.3-linux-amd64-debian-11/ spring-cloud-dataflow-composed-task-runner-2.11.0-RC1-linux-amd64-debian-11/
+
+# Archive and gzip, just like the original file we downloaded
+tar -czf spring-cloud-dataflow-composed-task-runner-2.11.0-RC1-linux-amd64-debian-11.tar.gz spring-cloud-dataflow-composed-task-runner-2.11.0-RC1-linux-amd64-debian-11/
+
+# Clean up
+rm -r spring-cloud-dataflow-composed-task-runner-2.10.3-3-linux-amd64-debian-11.tar.gz spring-cloud-dataflow-composed-task-runner-2.11.0-RC1-linux-amd64-debian-11/

--- a/bitnami/spring-cloud-dataflow/2/debian-11/.gitignore
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/.gitignore
@@ -1,0 +1,1 @@
+components/

--- a/bitnami/spring-cloud-dataflow/2/debian-11/Dockerfile
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/Dockerfile
@@ -59,7 +59,7 @@ RUN chmod g+rwX /opt/bitnami
 COPY rootfs /
 RUN /opt/bitnami/scripts/spring-cloud-dataflow/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
-ENV APP_VERSION="2.11.0-RC1" \
+ENV APP_VERSION="2.11.0" \
     BITNAMI_APP_NAME="spring-cloud-dataflow" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:$PATH"

--- a/bitnami/spring-cloud-dataflow/2/debian-11/Dockerfile
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/Dockerfile
@@ -11,10 +11,10 @@ LABEL com.vmware.cp.artifact.flavor="sha256:1e1b4657a77f0d47e9220f0c37b9bf780258
       org.opencontainers.image.created="2023-09-04T23:06:19Z" \
       org.opencontainers.image.description="Application packaged by VMware, Inc" \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="2.10.3-debian-11-r99" \
+      org.opencontainers.image.ref.name="2.11.0-RC1-debian-11-r99" \
       org.opencontainers.image.title="spring-cloud-dataflow" \
       org.opencontainers.image.vendor="VMware, Inc." \
-      org.opencontainers.image.version="2.10.3"
+      org.opencontainers.image.version="2.11.0-RC1"
 
 ENV HOME="/" \
     OS_ARCH="${TARGETARCH:-amd64}" \
@@ -29,7 +29,6 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "java-17.0.8-7-3-linux-${OS_ARCH}-debian-11" \
       "yq-4.35.1-0-linux-${OS_ARCH}-debian-11" \
-      "spring-cloud-dataflow-2.10.3-3-linux-${OS_ARCH}-debian-11" \
     ) && \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \
@@ -40,6 +39,18 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
+
+# Custom: also install local components in case Bitnami hasn't built the artifacts yet
+COPY components/* /tmp/bitnami/pkg/cache/
+RUN cd /tmp/bitnami/pkg/cache/ && \
+    LOCAL_COMPONENTS=( \
+      "spring-cloud-dataflow-2.11.0-RC1-linux-${OS_ARCH}-debian-11" \
+    ) && \
+    for LOCAL_COMPONENT in "${LOCAL_COMPONENTS[@]}"; do \
+      tar -zxf "${LOCAL_COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
+      rm -rf "${LOCAL_COMPONENT}".tar.gz{,.sha256} ; \
+    done
+
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
@@ -48,7 +59,7 @@ RUN chmod g+rwX /opt/bitnami
 COPY rootfs /
 RUN /opt/bitnami/scripts/spring-cloud-dataflow/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
-ENV APP_VERSION="2.10.3" \
+ENV APP_VERSION="2.11.0-RC1" \
     BITNAMI_APP_NAME="spring-cloud-dataflow" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:$PATH"

--- a/bitnami/spring-cloud-dataflow/2/debian-11/custom-jar.sh
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/custom-jar.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+
+mkdir components
+cd components
+
+# Download an existing GA archive
+wget https://downloads.bitnami.com/files/stacksmith/spring-cloud-dataflow-2.10.3-3-linux-amd64-debian-11.tar.gz
+# Explode it
+tar -xzf spring-cloud-dataflow-2.10.3-3-linux-amd64-debian-11.tar.gz
+
+# Navigate to JARs
+cd spring-cloud-dataflow-2.10.3-linux-amd64-debian-11/files/spring-cloud-dataflow/
+
+# Clean this - we'll replace with a different version
+rm *.jar
+
+wget https://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-dataflow-server/2.11.0-RC1/spring-cloud-dataflow-server-2.11.0-RC1.jar
+
+# This is symlinked in the original archive, so create another pointing to our version
+ln -s spring-cloud-dataflow-server-2.11.0-RC1.jar spring-cloud-dataflow.jar
+
+# Back out and rename to new version
+cd ../../../
+mv spring-cloud-dataflow-2.10.3-linux-amd64-debian-11/ spring-cloud-dataflow-2.11.0-RC1-linux-amd64-debian-11/
+
+# Archive and gzip, just like the original file we downloaded
+tar -czf spring-cloud-dataflow-2.11.0-RC1-linux-amd64-debian-11.tar.gz spring-cloud-dataflow-2.11.0-RC1-linux-amd64-debian-11/
+
+# Clean up
+rm -r spring-cloud-dataflow-2.10.3-3-linux-amd64-debian-11.tar.gz spring-cloud-dataflow-2.11.0-RC1-linux-amd64-debian-11/

--- a/bitnami/spring-cloud-skipper/2/debian-11/.gitignore
+++ b/bitnami/spring-cloud-skipper/2/debian-11/.gitignore
@@ -1,0 +1,1 @@
+components/

--- a/bitnami/spring-cloud-skipper/2/debian-11/Dockerfile
+++ b/bitnami/spring-cloud-skipper/2/debian-11/Dockerfile
@@ -11,10 +11,10 @@ LABEL com.vmware.cp.artifact.flavor="sha256:1e1b4657a77f0d47e9220f0c37b9bf780258
       org.opencontainers.image.created="2023-09-04T23:05:32Z" \
       org.opencontainers.image.description="Application packaged by VMware, Inc" \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="2.11.0-RC-debian-11-r112" \
+      org.opencontainers.image.ref.name="2.11.0-RC1-debian-11-r112" \
       org.opencontainers.image.title="spring-cloud-skipper" \
       org.opencontainers.image.vendor="VMware, Inc." \
-      org.opencontainers.image.version="2.11.0-RC"
+      org.opencontainers.image.version="2.11.0-RC1"
 
 ENV HOME="/" \
     OS_ARCH="${TARGETARCH:-amd64}" \
@@ -59,7 +59,7 @@ RUN chmod g+rwX /opt/bitnami
 COPY rootfs /
 RUN /opt/bitnami/scripts/spring-cloud-skipper/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
-ENV APP_VERSION="2.11.0-RC" \
+ENV APP_VERSION="2.11.0" \
     BITNAMI_APP_NAME="spring-cloud-skipper" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:$PATH"

--- a/bitnami/spring-cloud-skipper/2/debian-11/Dockerfile
+++ b/bitnami/spring-cloud-skipper/2/debian-11/Dockerfile
@@ -11,10 +11,10 @@ LABEL com.vmware.cp.artifact.flavor="sha256:1e1b4657a77f0d47e9220f0c37b9bf780258
       org.opencontainers.image.created="2023-09-04T23:05:32Z" \
       org.opencontainers.image.description="Application packaged by VMware, Inc" \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="2.9.3-debian-11-r112" \
+      org.opencontainers.image.ref.name="2.11.0-RC-debian-11-r112" \
       org.opencontainers.image.title="spring-cloud-skipper" \
       org.opencontainers.image.vendor="VMware, Inc." \
-      org.opencontainers.image.version="2.9.3"
+      org.opencontainers.image.version="2.11.0-RC"
 
 ENV HOME="/" \
     OS_ARCH="${TARGETARCH:-amd64}" \
@@ -29,7 +29,6 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "java-17.0.8-7-3-linux-${OS_ARCH}-debian-11" \
       "yq-4.35.1-0-linux-${OS_ARCH}-debian-11" \
-      "spring-cloud-skipper-2.9.3-3-linux-${OS_ARCH}-debian-11" \
     ) && \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \
@@ -40,6 +39,18 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
+
+# Custom: also install local components in case Bitnami hasn't built the artifacts yet
+COPY components/* /tmp/bitnami/pkg/cache/
+RUN cd /tmp/bitnami/pkg/cache/ && \
+    LOCAL_COMPONENTS=( \
+      "spring-cloud-skipper-2.11.0-RC1-linux-${OS_ARCH}-debian-11" \
+    ) && \
+    for LOCAL_COMPONENT in "${LOCAL_COMPONENTS[@]}"; do \
+      tar -zxf "${LOCAL_COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
+      rm -rf "${LOCAL_COMPONENT}".tar.gz{,.sha256} ; \
+    done
+
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
@@ -48,7 +59,7 @@ RUN chmod g+rwX /opt/bitnami
 COPY rootfs /
 RUN /opt/bitnami/scripts/spring-cloud-skipper/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
-ENV APP_VERSION="2.9.3" \
+ENV APP_VERSION="2.11.0-RC" \
     BITNAMI_APP_NAME="spring-cloud-skipper" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:$PATH"

--- a/bitnami/spring-cloud-skipper/2/debian-11/custom-jar.sh
+++ b/bitnami/spring-cloud-skipper/2/debian-11/custom-jar.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+
+mkdir components
+cd components
+
+# Download an existing GA archive
+wget https://downloads.bitnami.com/files/stacksmith/spring-cloud-skipper-2.9.3-3-linux-amd64-debian-11.tar.gz
+# Explode it
+tar -xzf spring-cloud-skipper-2.9.3-3-linux-amd64-debian-11.tar.gz
+
+# Navigate to JARs
+cd spring-cloud-skipper-2.9.3-linux-amd64-debian-11/files/spring-cloud-skipper/
+
+# Clean this - we'll replace with a different version
+rm *.jar
+
+wget https://repo.spring.io/milestone/org/springframework/cloud/spring-cloud-skipper-server/2.11.0-RC1/spring-cloud-skipper-server-2.11.0-RC1.jar
+
+# This is symlinked in the original archive, so create another pointing to our version
+ln -s spring-cloud-skipper-server-2.11.0-RC1.jar spring-cloud-skipper.jar
+
+# Back out and rename to new version
+cd ../../../
+mv spring-cloud-skipper-2.9.3-linux-amd64-debian-11/ spring-cloud-skipper-2.11.0-RC1-linux-amd64-debian-11/
+
+# Archive and gzip, just like the original file we downloaded
+tar -czf spring-cloud-skipper-2.11.0-RC1-linux-amd64-debian-11.tar.gz spring-cloud-skipper-2.11.0-RC1-linux-amd64-debian-11/
+
+# Clean up
+rm -r spring-cloud-skipper-2.9.3-3-linux-amd64-debian-11.tar.gz spring-cloud-skipper-2.11.0-RC1-linux-amd64-debian-11/


### PR DESCRIPTION
For each of Spring Cloud Dataflow Server, Spring Cloud Dataflow Compose Task Runner, and Spring Cloud Skipper, I made changes to build using 2.11.0-RC1 JARs.

The OOB Dockerfile downloads compressed archives for each of these off of Stacksmith, which seems to be Bitnami's package manager. Since the archives aren't available for 2.11.0 since it's not GA yet, I added in a script mainly to show how I created my own.

Inside each archive is a JAR for the application (e.g. Spring Cloud Dataflow Server) and a symbolic link to that JAR. To substitute my own JAR (the ones from the Spring Milestones Maven repository), I added a script mainly to show the steps that I was doing manually:

1. Download an existing archive off of Stacksmith (package by Bitnami)
2. Decompress and explode the archive
3. Remove the JAR and symlink to JAR
4. Download the new JAR
5. Recreate the symlink pointing to the new JAR
6. Rename references of the old version to the new version
7. Archive and compress to emulate the original archive

I then added a snippet to the Dockerfile to install this archive from the filesystem rather than downloading it off of Stacksmith. I also updated versions mentioned in the Dockerfile, then built and pushed to our Artifactory.

This is hopefully a one-off hack, but I wanted to show how I ended up with these images.

Note this is a public fork.